### PR TITLE
enabled scrolling in long timetable

### DIFF
--- a/frontend/src/components/TimeGrid.tsx
+++ b/frontend/src/components/TimeGrid.tsx
@@ -214,7 +214,7 @@ export const TimeGrid = ({
   }, []);
 
   return (
-    <div className="max-w-fit select-none">
+    <div className="max-w-fit overflow-x-auto select-none">
       <Table className="w-auto">
         <TableHeader>
           <TableRow className="w-auto">


### PR DESCRIPTION
Simply added layout overflow css. resolve #6 

<img width="953" height="640" alt="image" src="https://github.com/user-attachments/assets/cbeff264-b811-46c0-bf7e-01d3d2286a61" />
