### PR TITLE
Link docs hierarchy from README so all .md files are reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ https://github.com/user-attachments/assets/29d921fc-4514-4b20-917c-f4a03be7796b
 ## ⚒️ Contributing
 
 We welcome contributions! If you have suggestions or improvements, please open an issue or submit a pull request.
+
+## 📚 Documentation
+
+- [docs/design/](docs/design/README.md) — Architectural design documents
+- [docs/tasks/](docs/tasks/README.md) — Task tracking (active and archived)
+- [backend/](backend/README.md) — Backend service notes
+- [CLAUDE.md](CLAUDE.md) — Agent instructions for AI-assisted development

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,8 +1,8 @@
 ---
-updated: 2026-03-25
+updated: 2026-04-29
 ---
 
 # Tasks
 
-- `active/` — In-progress tasks
-- `archive/` — Completed tasks
+- [active/](active/README.md) — In-progress tasks
+- [archive/](archive/README.md) — Completed tasks


### PR DESCRIPTION
## Summary

- Add a Documentation section to \`README.md\` linking \`docs/design/\`, \`docs/tasks/\`, \`backend/README.md\`, and \`CLAUDE.md\` so they are reachable from the project's entry point.
- Convert inline-code path references in \`docs/tasks/README.md\` to real markdown links.

Found via the link connectivity check script being added to second-brain ([yorkie-team/second-brain#34](https://github.com/yorkie-team/second-brain/pull/34)).

## Test plan

- [x] Verified the new links resolve to existing files
- [ ] Reviewer to spot-check the new Documentation section